### PR TITLE
fix janky wayland mouselook

### DIFF
--- a/wine-tkg-git/wine-tkg-userpatches/staging/xiv-wayland-mouselook.patch
+++ b/wine-tkg-git/wine-tkg-userpatches/staging/xiv-wayland-mouselook.patch
@@ -1,0 +1,25 @@
+From ec2cca0efaeddb758a4d7698bc5e3b4380865248 Mon Sep 17 00:00:00 2001
+From: khyperia <953151+khyperia@users.noreply.github.com>
+Date: Wed, 30 Apr 2025 20:26:19 +0200
+Subject: [PATCH] Set covers_vscreen to true to fix janky mouselook
+
+---
+ dlls/winewayland.drv/wayland_pointer.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/dlls/winewayland.drv/wayland_pointer.c b/dlls/winewayland.drv/wayland_pointer.c
+index beb9cc06702..3ffad5f645d 100644
+--- a/dlls/winewayland.drv/wayland_pointer.c
++++ b/dlls/winewayland.drv/wayland_pointer.c
+@@ -879,7 +879,7 @@ BOOL WAYLAND_ClipCursor(const RECT *clip, BOOL reset)
+     {
+         wl_surface = surface->wl_surface;
+         if (clip) wayland_surface_calc_confine(surface, clip, &confine_rect);
+-        covers_vscreen = wayland_surface_client_covers_vscreen(surface);
++        covers_vscreen = TRUE;
+         wayland_surface_coords_from_window(surface,
+                 cursor_pos.x - surface->window.rect.left,
+                 cursor_pos.y - surface->window.rect.top,
+-- 
+2.49.0
+


### PR DESCRIPTION
fixes https://github.com/rankynbass/unofficial-wine-xiv-git/issues/2

As discussed in that issue, `covers_vscreen` is true when you have one monitor, and is false when you have two. Because ffxiv mouselook works great when I only have monitor, but is busted with two, this PR is hitting it with a hammer to send it to the good place.

I have built with this patch locally and verified this fixes the issue for me with two monitors.

(i am almost certain this is not the correct fix for upstreaming for general application use, but it works good enough for ffxiv)